### PR TITLE
Add co-owner and fee  - NEW

### DIFF
--- a/ERC4908.md
+++ b/ERC4908.md
@@ -1,271 +1,136 @@
 ---
-eip: 4908
-title: Gated resources NFT access, an extension of EIP-721
-description: Allows resources providers for on-chain users to mint NFTs for their particular resource ID that can be used to access gated information
-author: Cromatikap (@cromatikap), Velitchko Filipov (@velitchko), BChainbuddy (@BChainbuddy)
-discussions-to: TODO -> open discussion on https://ethereum-magicians.org/
-status: Idea
-type: Standards Track
-category: ERC
-created: 2024-06-04
-requires: 721
----
 
-# ERC-4908: Gated resources NFT access
+# ERC-4908 (Fork): Gated resources NFT access with external minting and revenue split
 
 ## Table of Contents
 
-- [Abstract](#abstract)
-- [Motivation](#motivation)
-- [Specification](#specification)
-  - [Contract Interface](#contract-interface)
-  - [Reference Implementation](#reference-implementation)
-  - [Example implementation](#example-implementation)
-- [Rationale](#rationale)
-- [Test Cases](#test-cases)
-- [Copyright](#copyright)
+* [Abstract](#abstract)
+* [Motivation](#motivation)
+* [Specification](#specification)
 
+  * [Contract Interface](#contract-interface)
+  * [Reference Implementation](#reference-implementation)
+  * [Example Minting Contract](#example-minting-contract)
+* [Rationale](#rationale)
+* [Test Cases](#test-cases)
+* [Copyright](#copyright)
 
 ## Abstract
 
-This standard is an extension of [EIP-721](https://eips.ethereum.org/EIPS/eip-721) that allows for the creation of NFTs that can be used to access gated resources such as information, database or real world assets (RWA). The NFTs are allowed by the resource author to be minted by anyone on chain. The author specifies a mint price and an access expiration time. The NFTs can be transferred to other users, who can then access the information for the remaining time.
-The NFT ownership and expiration time is verified on-chain by the contract.
+This standard is a fork of [EIP-4908](https://eips.ethereum.org/EIPS/eip-4908) extending [ERC-721](https://eips.ethereum.org/EIPS/eip-721) to enable gated access to off-chain resources via NFTs. In this version, minting functionality is delegated to an external contract, allowing for custom minting strategies. Additionally, co-ownership and revenue split parameters are introduced, enabling collaborative monetization models.
 
 ## Motivation
 
-Tailored for the needs of the [Ipal platform](https://app.ipal.network/). The goal is similar to [eip-4907 rentable NFTs](https://eips.ethereum.org/EIPS/eip-4907) but with a radicaly different approach. The emphasis is on the off-chain verification of the contract state for an information management platform to take a decision whether or not to give acces based on user's holdings of its NFTs.
-The user keeps the ability to transfer or put on sale the expired NFTs which the value could be drawn from the historical event of having a past access. 
+The fork was designed for increased modularity and flexibility in platforms that manage access to digital or real-world resources. Key changes:
+
+* **Minting separated** from the core access logic, supporting external custom mint modules.
+* **Co-ownership (**\`\`**)** support for collaborative projects.
+* **Split fee (**\`\`**)** between the author and a designated co-owner, with fee base of 10000 (e.g., 3000 = 30%).
+
+This modularity aligns with real-world usage such as creator platforms, DAOs, educational content, and marketplaces.
 
 ## Specification
 
-The keywords “MUST”, “MUST NOT”, “REQUIRED”, “SHALL”, “SHALL NOT”, “SHOULD”, “SHOULD NOT”, “RECOMMENDED”, “MAY” and “OPTIONAL” in this document are to be interpreted as described in RFC 2119.
-
 ### Contract Interface
-
-Solidity Interface with NatSpec & OpenZeppelin v5 Interfaces (also available at [IERC4908.sol](IERC4908.sol)):
 
 ```solidity
 interface IERC4908 {
-    /// @notice Allows content access NFT to be minted
-    /// @dev This function is meant to be called by the content author
-    /// @param resourceId The content identification from the off-chain content service provider
-    /// @param price The mint price, in other terms the access price for this particular content
-    /// @param expirationTime The expiration time of the access
+    /// @notice Registers gated content access
     function setAccess(
-        uint256 resourceId,
+        string calldata resourceId,
         uint256 price,
-        uint32 expirationTime
+        uint32 expirationDuration,
+        address coOwner,
+        uint32 splitFee
     ) external;
 
-    /// @notice Disallows content access NFT to be minted, the remaining NFTs can still be used
-    /// @dev This function is meant to be called by the content author
-    /// @param resourceId The content identification from the off-chain content service provider
-    function delAccess(uint256 resourceId) external;
+    /// @notice Deletes gated access settings
+    function delAccess(string calldata resourceId) external;
 
-    /// @notice Check for the access to a particular content from a particular consumer
-    /// @dev This function is meant to be called by the content provider, the 2 first parameters
-    ///      are meant to certify that the content ID is owned by the author while the last
-    ///      `consumer` parameter is used to find if the consumer owns an NFT for this content
-    ///      that is not expired.
-    /// @param author The address of the content author
-    /// @param resourceId The content identification from the off-chain content service provider
-    /// @param consumer The address of the content consumer
-    /// @return response True if the consumer has access to the content, false otherwise
-    /// @return message A message indicating the access status: "access doesn't exist", "access is expired", "access granted" or "user doesn't own the NFT"
+    /// @notice Checks access for a consumer
     function hasAccess(
         address author,
-        uint256 resourceId,
+        string calldata resourceId,
         address consumer
-    ) external view returns (bool response, string memory message);
+    ) external view returns (bool response, string memory message, int32 expirationTime);
 
-    /// @notice Check if the given access hash exists
-    /// @dev This function is called internally but can be also handy for external use
-    /// @param hash The hash of the author and resourceId, used as the index of settings mapping
-    /// @return response True if the access hash exists, false otherwise
-    function existAccess(bytes32 hash) external view returns (bool response);
+    /// @notice Checks if access settings exist
+    function existAccess(address author, string calldata resourceId) external view returns (bool);
 
-    /// @notice Mints a content access NFT
-    /// @dev This function is meant to be called by the content consumer
-    /// @param author address hashed with resourceId to retrieve the content settings specified by the author
-    /// @param resourceId The content identification from the off-chain content service provider
-    /// @param to The address of the content consumer
-    function mint(
+    /// @notice Returns access settings
+    function getAccessControl(
         address author,
-        uint256 resourceId,
-        address to
-    ) external payable;
-
-    /// @notice The author hasn't activated mint access for this resourceId
-    /// @param accessHash The hash of the author and resourceId, used as the index of settings mapping
-    error MintUnavailable(bytes32 accessHash);
-
-    /// @notice The author's minting fee has not been met by the consumer
-    /// @param expectedPrice A message indicating the minting fee is not met
-    error InsufficientFunds(uint256 expectedPrice);
+        string calldata resourceId
+    ) external view returns (
+        uint256 price,
+        uint32 expirationDuration,
+        address coOwner,
+        uint32 splitFee
+    );
 }
 ```
 
-The `setAccess(uint256 resourceId, uint256 price, uint32 expirationTime)` function MAY be implemented as `public` or `external`.
+### Reference Implementation
 
-The `delAccess(uint256 resourceId)` function MAY be implemented as `public` or `external`.
+See [ERC4908.sol](./contracts/ERC4908.sol) for the abstract contract. It:
 
-The `hasAccess(address author, uint256 resourceId, address consumer)` function MAY be implemented as `view`.
+* Stores access settings (`price`, `expirationDuration`, `coOwner`, `splitFee`) per `(author, resourceId)` pair
+* Tracks ownership and expiration of access NFTs
+* Does **not** include minting logic (delegated externally)
 
-The `existAccess(bytes32 hash)` function MAY be implemented as `view`.
-
-The `mint(address author, uint256 resourceId, address to)` function MAY be implemented as `public` or `external`.
-
-## Reference Implementation
-
-Abstract implementation: [ERC4908.sol](ERC4908.sol)
+### Example Minting Contract
 
 ```solidity
-// SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.24;
-
-import {ERC721} from "@openzeppelin/contracts/token/ERC721/ERC721.sol";
-import {ERC721Enumerable} from "@openzeppelin/contracts/token/ERC721/extensions/ERC721Enumerable.sol";
-import {IERC4908} from "./IERC4908.sol";
-
-abstract contract ERC4908 is IERC4908, ERC721, ERC721Enumerable {
-    struct Settings {
-        uint256 resourceId;
-        uint256 price;
-        uint32 expirationTime;
-    }
-    mapping(bytes32 hash => Settings) public accessControl;
-
-    // struct attached to each NFT id
-    struct Metadata {
-        bytes32 hash;
-        uint256 resourceId;
-        uint32 expirationTime;
+contract MintManager {
+    IERC4908 public erc4908;
+    constructor(address _erc4908) {
+        erc4908 = IERC4908(_erc4908);
     }
 
-    mapping(uint256 => Metadata) public nftData;
-
-    constructor(
-        string memory name_,
-        string memory symbol_
-    ) ERC721(name_, symbol_) {}
-
-    function _hash(
+    function mintAccessNFT(
         address author,
-        uint256 resourceId
-    ) private pure returns (bytes32) {
-        return keccak256(abi.encodePacked(author, resourceId));
-    }
-
-    function _setAccess(
-        address author,
-        uint256 resourceId,
-        uint256 price,
-        uint32 expirationTime
-    ) private {
-        bytes32 hash = _hash(author, resourceId);
-        accessControl[hash] = Settings(resourceId, price, expirationTime);
-    }
-
-    function setAccess(
-        uint256 resourceId,
-        uint256 price,
-        uint32 expirationTime
-    ) external {
-        _setAccess(msg.sender, resourceId, price, expirationTime);
-    }
-
-    function existAccess(bytes32 hash) external view returns (bool) {
-        return accessControl[hash].resourceId != 0;
-    }
-
-    function mint(
-        address author,
-        uint256 resourceId,
+        string calldata resourceId,
         address to
-    ) public payable virtual {
-        bytes32 settingsIndex = _hash(author, resourceId);
-        if (!this.existAccess(settingsIndex))
-            revert MintUnavailable(settingsIndex);
+    ) external payable {
+        (uint256 price, uint32 duration, address coOwner, uint32 splitFee) =
+            erc4908.getAccessControl(author, resourceId);
 
-        uint256 price = accessControl[settingsIndex].price;
+        require(price > 0, "Access not available");
+        require(msg.value >= price, "Insufficient payment");
 
-        if (msg.value < price) {
-            revert InsufficientFunds(price);
+        uint256 coShare = (price * splitFee) / 10000;
+        uint256 authorShare = price - coShare;
+
+        payable(author).transfer(authorShare);
+        if (coOwner != address(0) && coShare > 0) {
+            payable(coOwner).transfer(coShare);
         }
 
-        uint256 tokenId = totalSupply();
-
-        nftData[tokenId] = Metadata(
-            settingsIndex,
-            accessControl[settingsIndex].resourceId,
-            accessControl[settingsIndex].expirationTime
-        );
-
-        _safeMint(to, tokenId);
-    }
-
-    function hasAccess(
-        address author,
-        uint256 resourceId,
-        address consumer
-    ) external view returns (bool response, string memory message) {
-        bytes32 hash = _hash(author, resourceId);
-
-        if (!this.existAccess(hash)) {
-            return (false, "access doesn't exist");
-        }
-
-        for (uint256 i = 0; i < balanceOf(consumer); i++) {
-            uint256 tokenId = tokenOfOwnerByIndex(consumer, i);
-            Metadata memory metadata = nftData[tokenId];
-
-            if (metadata.hash == hash) {
-                if (block.timestamp > metadata.expirationTime) {
-                    return (false, "access is expired");
-                }
-                return (true, "access granted");
-            }
-        }
-        return (false, "user doesn't own the NFT");
-    }
-
-    function delAccess(uint256 resourceId) external {
-        bytes32 hash = _hash(msg.sender, resourceId);
-        delete accessControl[hash];
-    }
-
-    /*
-     * overrides required for the ERC721 Enumerable extension
-     */
-
-    function _update(
-        address to,
-        uint256 tokenId,
-        address auth
-    ) internal virtual override(ERC721, ERC721Enumerable) returns (address) {
-        return super._update(to, tokenId, auth);
-    }
-
-    function _increaseBalance(
-        address account,
-        uint128 value
-    ) internal virtual override(ERC721, ERC721Enumerable) {
-        super._increaseBalance(account, value);
-    }
-
-    function supportsInterface(
-        bytes4 interfaceId
-    ) public view virtual override(ERC721, ERC721Enumerable) returns (bool) {
-        return super.supportsInterface(interfaceId);
+        // Call mint logic (assumed implemented elsewhere)
+        // e.g., erc4908.mintNFT(to, resourceId);
     }
 }
 ```
 
-### Example implementation
+## Rationale
 
-Example implementations are available at:
-- [_Example.sol](_Example.sol)
-- [GatedKnowledgeManager.sol](../GatedKnowledgeManager.sol)
+Separating minting into a sub-contract allows the core standard to remain minimal and agnostic to business logic. This makes it adaptable to:
+
+* Pay-per-access
+* Subscriptions
+* Auctions
+* Whitelisted claims
+
+Revenue split and co-ownership reflect real-world collaborations between authors, editors, and platforms.
+
+## Test Cases
+
+Test coverage must include:
+
+* Access lifecycle (`setAccess`, `hasAccess`, `delAccess`)
+* Edge cases for expiration and invalid consumers
+* Split fee logic with and without coOwner
+* External mint flow validation
 
 ## Copyright
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ERC-4908: Gated resources NFT access
 
-Tailored for the needs of the [Ipal platform](https://app.ipal.network/), a web3 friendly [knowledge management platform](https://en.wikipedia.org/wiki/Knowledge_management_software).
+Tailored for the needs of the [Ipal platform](https://ipal.network/), a web3 friendly [knowledge management platform](https://en.wikipedia.org/wiki/Knowledge_management_software).
 See the [specification](./ERC4908.md) for more details.
 
 ## Platform implementation

--- a/contracts/ERC4908.sol
+++ b/contracts/ERC4908.sol
@@ -11,6 +11,8 @@ abstract contract ERC4908 is IERC4908, ERC721, ERC721Enumerable {
         string resourceId;
         uint256 price;
         uint32 expirationDuration;
+        address coOwner;
+        uint32 splitFee; // base 10000 (ex: 3000 = 30%)
     }
     mapping(bytes32 => Settings) public accessControl;
 
@@ -31,7 +33,7 @@ abstract contract ERC4908 is IERC4908, ERC721, ERC721Enumerable {
     function _hash(
         address author,
         string calldata resourceId
-    ) private pure returns (bytes32) {
+    ) internal pure returns (bytes32) {
         return keccak256(abi.encodePacked(author, resourceId));
     }
 
@@ -39,18 +41,22 @@ abstract contract ERC4908 is IERC4908, ERC721, ERC721Enumerable {
         address author,
         string calldata resourceId,
         uint256 price,
-        uint32 expirationDuration
+        uint32 expirationDuration,
+        address coOwner,
+        uint32 splitFee
     ) private {
         bytes32 hash = _hash(author, resourceId);
-        accessControl[hash] = Settings(resourceId, price, expirationDuration);
+        accessControl[hash] = Settings(resourceId, price, expirationDuration, coOwner, splitFee);
     }
 
     function setAccess(
         string calldata resourceId,
         uint256 price,
-        uint32 expirationDuration
+        uint32 expirationDuration,
+        address coOwner,
+        uint32 splitFee
     ) public {
-        _setAccess(msg.sender, resourceId, price, expirationDuration);
+        _setAccess(msg.sender, resourceId, price, expirationDuration, coOwner, splitFee);
     }
 
     function existAccess(bytes32 hash) external view returns (bool) {
@@ -70,42 +76,15 @@ abstract contract ERC4908 is IERC4908, ERC721, ERC721Enumerable {
         external
         view
         override
-        returns (uint256 price, uint32 expirationDuration)
+        returns (uint256 price, uint32 expirationDuration, address coOwner, uint32 splitFee)
     {
         bytes32 hash = _hash(author, resourceId);
         return (
             accessControl[hash].price,
-            accessControl[hash].expirationDuration
+            accessControl[hash].expirationDuration,
+            accessControl[hash].coOwner,
+            accessControl[hash].splitFee
         );
-    }
-
-    function mint(
-        address payable author,
-        string calldata resourceId,
-        address to
-    ) public payable virtual {
-        bytes32 settingsIndex = _hash(author, resourceId);
-        if (!this.existAccess(settingsIndex))
-            revert MintUnavailable(settingsIndex);
-
-        uint256 price = accessControl[settingsIndex].price;
-
-        if (msg.value < price) {
-            revert InsufficientFunds(price);
-        }
-
-        uint256 tokenId = totalSupply();
-
-        nftData[tokenId] = Metadata(
-            settingsIndex,
-            accessControl[settingsIndex].resourceId,
-            accessControl[settingsIndex].expirationDuration +
-                uint32(block.timestamp)
-        );
-
-        author.transfer(msg.value);
-
-        _safeMint(to, tokenId);
     }
 
     function hasAccess(

--- a/contracts/IERC4908.sol
+++ b/contracts/IERC4908.sol
@@ -7,10 +7,14 @@ interface IERC4908 {
     /// @param resourceId The content identification from the off-chain content service provider
     /// @param price The mint price, in other terms the access price for this particular content
     /// @param expirationDuration The expiration time of the access
+    /// @param coOwner The address of the co-owner of the content, if any
+    /// @param splitFee The fee split percentage for the co-owner, base 10000 (ex: 3000 = 30%)
     function setAccess(
         string calldata resourceId,
         uint256 price,
-        uint32 expirationDuration
+        uint32 expirationDuration,
+        address coOwner,
+        uint32 splitFee
     ) external;
 
     /// @notice Disallows content access NFT to be minted, the remaining NFTs can still be used
@@ -60,21 +64,12 @@ interface IERC4908 {
     /// @param resourceId The content identification from the off-chain service provider
     /// @return price The mint price, in other terms the access price for this particular resource
     /// @return expirationDuration The duration of the access for each NFT minted
+    /// @return coOwner The address of the co-owner of the content, if any
+    /// @return splitFee The fee split percentage for the co-owner, base 10000 (ex: 3000 = 30%)
     function getAccessControl(
         address author,
         string calldata resourceId
-    ) external view returns (uint256 price, uint32 expirationDuration);
-
-    /// @notice Mints a content access NFT
-    /// @dev This function is meant to be called by the content consumer
-    /// @param author address hashed with resourceId to retrieve the content settings specified by the author
-    /// @param resourceId The content identification from the off-chain content service provider
-    /// @param to The address of the content consumer
-    function mint(
-        address payable author,
-        string calldata resourceId,
-        address to
-    ) external payable;
+    ) external view returns (uint256 price, uint32 expirationDuration, address coOwner, uint32 splitFee);
 
     /// @notice The author hasn't activated mint access for this resourceId
     /// @param accessHash The hash of the author and resourceId, used as the index of settings mapping

--- a/release-notes/ERC4908.md
+++ b/release-notes/ERC4908.md
@@ -1,0 +1,272 @@
+---
+eip: 4908
+title: Gated resources NFT access, an extension of EIP-721
+description: Allows resources providers for on-chain users to mint NFTs for their particular resource ID that can be used to access gated information
+author: Cromatikap (@cromatikap), Velitchko Filipov (@velitchko), BChainbuddy (@BChainbuddy)
+discussions-to: TODO -> open discussion on https://ethereum-magicians.org/
+status: Idea
+type: Standards Track
+category: ERC
+created: 2024-06-04
+requires: 721
+---
+
+# ERC-4908: Gated resources NFT access
+
+## Table of Contents
+
+- [Abstract](#abstract)
+- [Motivation](#motivation)
+- [Specification](#specification)
+  - [Contract Interface](#contract-interface)
+  - [Reference Implementation](#reference-implementation)
+  - [Example implementation](#example-implementation)
+- [Rationale](#rationale)
+- [Test Cases](#test-cases)
+- [Copyright](#copyright)
+
+
+## Abstract
+
+This standard is an extension of [EIP-721](https://eips.ethereum.org/EIPS/eip-721) that allows for the creation of NFTs that can be used to access gated resources such as information, database or real world assets (RWA). The NFTs are allowed by the resource author to be minted by anyone on chain. The author specifies a mint price and an access expiration time. The NFTs can be transferred to other users, who can then access the information for the remaining time.
+The NFT ownership and expiration time is verified on-chain by the contract.
+
+## Motivation
+
+Tailored for the needs of the [Ipal platform](https://app.ipal.network/). The goal is similar to [eip-4907 rentable NFTs](https://eips.ethereum.org/EIPS/eip-4907) but with a radicaly different approach. The emphasis is on the off-chain verification of the contract state for an information management platform to take a decision whether or not to give acces based on user's holdings of its NFTs.
+The user keeps the ability to transfer or put on sale the expired NFTs which the value could be drawn from the historical event of having a past access. 
+
+## Specification
+
+The keywords “MUST”, “MUST NOT”, “REQUIRED”, “SHALL”, “SHALL NOT”, “SHOULD”, “SHOULD NOT”, “RECOMMENDED”, “MAY” and “OPTIONAL” in this document are to be interpreted as described in RFC 2119.
+
+### Contract Interface
+
+Solidity Interface with NatSpec & OpenZeppelin v5 Interfaces (also available at [IERC4908.sol](IERC4908.sol)):
+
+```solidity
+interface IERC4908 {
+    /// @notice Allows content access NFT to be minted
+    /// @dev This function is meant to be called by the content author
+    /// @param resourceId The content identification from the off-chain content service provider
+    /// @param price The mint price, in other terms the access price for this particular content
+    /// @param expirationTime The expiration time of the access
+    function setAccess(
+        uint256 resourceId,
+        uint256 price,
+        uint32 expirationTime
+    ) external;
+
+    /// @notice Disallows content access NFT to be minted, the remaining NFTs can still be used
+    /// @dev This function is meant to be called by the content author
+    /// @param resourceId The content identification from the off-chain content service provider
+    function delAccess(uint256 resourceId) external;
+
+    /// @notice Check for the access to a particular content from a particular consumer
+    /// @dev This function is meant to be called by the content provider, the 2 first parameters
+    ///      are meant to certify that the content ID is owned by the author while the last
+    ///      `consumer` parameter is used to find if the consumer owns an NFT for this content
+    ///      that is not expired.
+    /// @param author The address of the content author
+    /// @param resourceId The content identification from the off-chain content service provider
+    /// @param consumer The address of the content consumer
+    /// @return response True if the consumer has access to the content, false otherwise
+    /// @return message A message indicating the access status: "access doesn't exist", "access is expired", "access granted" or "user doesn't own the NFT"
+    function hasAccess(
+        address author,
+        uint256 resourceId,
+        address consumer
+    ) external view returns (bool response, string memory message);
+
+    /// @notice Check if the given access hash exists
+    /// @dev This function is called internally but can be also handy for external use
+    /// @param hash The hash of the author and resourceId, used as the index of settings mapping
+    /// @return response True if the access hash exists, false otherwise
+    function existAccess(bytes32 hash) external view returns (bool response);
+
+    /// @notice Mints a content access NFT
+    /// @dev This function is meant to be called by the content consumer
+    /// @param author address hashed with resourceId to retrieve the content settings specified by the author
+    /// @param resourceId The content identification from the off-chain content service provider
+    /// @param to The address of the content consumer
+    function mint(
+        address author,
+        uint256 resourceId,
+        address to
+    ) external payable;
+
+    /// @notice The author hasn't activated mint access for this resourceId
+    /// @param accessHash The hash of the author and resourceId, used as the index of settings mapping
+    error MintUnavailable(bytes32 accessHash);
+
+    /// @notice The author's minting fee has not been met by the consumer
+    /// @param expectedPrice A message indicating the minting fee is not met
+    error InsufficientFunds(uint256 expectedPrice);
+}
+```
+
+The `setAccess(uint256 resourceId, uint256 price, uint32 expirationTime)` function MAY be implemented as `public` or `external`.
+
+The `delAccess(uint256 resourceId)` function MAY be implemented as `public` or `external`.
+
+The `hasAccess(address author, uint256 resourceId, address consumer)` function MAY be implemented as `view`.
+
+The `existAccess(bytes32 hash)` function MAY be implemented as `view`.
+
+The `mint(address author, uint256 resourceId, address to)` function MAY be implemented as `public` or `external`.
+
+## Reference Implementation
+
+Abstract implementation: [ERC4908.sol](ERC4908.sol)
+
+```solidity
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.24;
+
+import {ERC721} from "@openzeppelin/contracts/token/ERC721/ERC721.sol";
+import {ERC721Enumerable} from "@openzeppelin/contracts/token/ERC721/extensions/ERC721Enumerable.sol";
+import {IERC4908} from "./IERC4908.sol";
+
+abstract contract ERC4908 is IERC4908, ERC721, ERC721Enumerable {
+    struct Settings {
+        uint256 resourceId;
+        uint256 price;
+        uint32 expirationTime;
+    }
+    mapping(bytes32 hash => Settings) public accessControl;
+
+    // struct attached to each NFT id
+    struct Metadata {
+        bytes32 hash;
+        uint256 resourceId;
+        uint32 expirationTime;
+    }
+
+    mapping(uint256 => Metadata) public nftData;
+
+    constructor(
+        string memory name_,
+        string memory symbol_
+    ) ERC721(name_, symbol_) {}
+
+    function _hash(
+        address author,
+        uint256 resourceId
+    ) private pure returns (bytes32) {
+        return keccak256(abi.encodePacked(author, resourceId));
+    }
+
+    function _setAccess(
+        address author,
+        uint256 resourceId,
+        uint256 price,
+        uint32 expirationTime
+    ) private {
+        bytes32 hash = _hash(author, resourceId);
+        accessControl[hash] = Settings(resourceId, price, expirationTime);
+    }
+
+    function setAccess(
+        uint256 resourceId,
+        uint256 price,
+        uint32 expirationTime
+    ) external {
+        _setAccess(msg.sender, resourceId, price, expirationTime);
+    }
+
+    function existAccess(bytes32 hash) external view returns (bool) {
+        return accessControl[hash].resourceId != 0;
+    }
+
+    function mint(
+        address author,
+        uint256 resourceId,
+        address to
+    ) public payable virtual {
+        bytes32 settingsIndex = _hash(author, resourceId);
+        if (!this.existAccess(settingsIndex))
+            revert MintUnavailable(settingsIndex);
+
+        uint256 price = accessControl[settingsIndex].price;
+
+        if (msg.value < price) {
+            revert InsufficientFunds(price);
+        }
+
+        uint256 tokenId = totalSupply();
+
+        nftData[tokenId] = Metadata(
+            settingsIndex,
+            accessControl[settingsIndex].resourceId,
+            accessControl[settingsIndex].expirationTime
+        );
+
+        _safeMint(to, tokenId);
+    }
+
+    function hasAccess(
+        address author,
+        uint256 resourceId,
+        address consumer
+    ) external view returns (bool response, string memory message) {
+        bytes32 hash = _hash(author, resourceId);
+
+        if (!this.existAccess(hash)) {
+            return (false, "access doesn't exist");
+        }
+
+        for (uint256 i = 0; i < balanceOf(consumer); i++) {
+            uint256 tokenId = tokenOfOwnerByIndex(consumer, i);
+            Metadata memory metadata = nftData[tokenId];
+
+            if (metadata.hash == hash) {
+                if (block.timestamp > metadata.expirationTime) {
+                    return (false, "access is expired");
+                }
+                return (true, "access granted");
+            }
+        }
+        return (false, "user doesn't own the NFT");
+    }
+
+    function delAccess(uint256 resourceId) external {
+        bytes32 hash = _hash(msg.sender, resourceId);
+        delete accessControl[hash];
+    }
+
+    /*
+     * overrides required for the ERC721 Enumerable extension
+     */
+
+    function _update(
+        address to,
+        uint256 tokenId,
+        address auth
+    ) internal virtual override(ERC721, ERC721Enumerable) returns (address) {
+        return super._update(to, tokenId, auth);
+    }
+
+    function _increaseBalance(
+        address account,
+        uint128 value
+    ) internal virtual override(ERC721, ERC721Enumerable) {
+        super._increaseBalance(account, value);
+    }
+
+    function supportsInterface(
+        bytes4 interfaceId
+    ) public view virtual override(ERC721, ERC721Enumerable) returns (bool) {
+        return super.supportsInterface(interfaceId);
+    }
+}
+```
+
+### Example implementation
+
+Example implementations are available at:
+- [_Example.sol](_Example.sol)
+- [GatedKnowledgeManager.sol](../GatedKnowledgeManager.sol)
+
+## Copyright
+
+Copyright and related rights waived via [CC0](https://eips.ethereum.org/LICENSE).

--- a/test/ERC4908Example.ts
+++ b/test/ERC4908Example.ts
@@ -2,7 +2,7 @@ import hre from "hardhat";
 import { loadFixture } from "@nomicfoundation/hardhat-toolbox-viem/network-helpers";
 import { expect } from "chai";
 import { keccak256, encodePacked } from "viem";
-import { getBalance, getBlockTimestamp, impersonate, increaseTime, paramsDefault } from "./utils";
+import { paramsDefault } from "./utils";
 
 describe("ERC4908", function () {
   async function deployERC4908ExampleFixture() {
@@ -23,7 +23,7 @@ describe("ERC4908", function () {
       /* Arrange */
 
       const { erc4908Example, wallet } = await loadFixture(deployERC4908ExampleFixture);
-      const { resourceId, price, expirationDuration } = paramsDefault;
+      const { resourceId, price, expirationDuration, coOwner, splitFee } = paramsDefault;
 
       const expectedHash = keccak256(encodePacked(
         ['address', 'string'],
@@ -32,7 +32,7 @@ describe("ERC4908", function () {
 
       /* Act */
 
-      await erc4908Example.write.setAccess([resourceId, price, expirationDuration])
+      await erc4908Example.write.setAccess([resourceId, price, expirationDuration, coOwner, splitFee])
       const access = await erc4908Example.read.accessControl([expectedHash]);
 
       /* Assert */
@@ -40,6 +40,8 @@ describe("ERC4908", function () {
       expect(access[0]).to.equal(resourceId);
       expect(access[1]).to.equal(price);
       expect(access[2]).to.equal(expirationDuration);
+      expect(access[3]).to.equal(coOwner);
+      expect(access[4]).to.equal(splitFee)
     });
 
     it("Should check if access exists using hash", async function () {
@@ -47,7 +49,7 @@ describe("ERC4908", function () {
       /* Arrange */
 
       const { erc4908Example, wallet } = await loadFixture(deployERC4908ExampleFixture);
-      const { resourceId, price, expirationDuration } = paramsDefault;
+      const { resourceId, price, expirationDuration, coOwner, splitFee } = paramsDefault;
 
       const expectedHash = keccak256(encodePacked(
         ['address', 'string'],
@@ -57,7 +59,7 @@ describe("ERC4908", function () {
       /* Act */
 
       const before = await erc4908Example.read.existAccess([expectedHash]);
-      await erc4908Example.write.setAccess([resourceId, price, expirationDuration]);
+      await erc4908Example.write.setAccess([resourceId, price, expirationDuration, coOwner, splitFee]);
       const after = await erc4908Example.read.existAccess([expectedHash]);
 
       /* Assert */
@@ -71,12 +73,12 @@ describe("ERC4908", function () {
       /* Arrange */
 
       const { erc4908Example, wallet } = await loadFixture(deployERC4908ExampleFixture);
-      const { resourceId, price, expirationDuration } = paramsDefault;
+      const { resourceId, price, expirationDuration, coOwner, splitFee } = paramsDefault;
 
       /* Act */
 
       const before = await erc4908Example.read.existAccess([wallet.account.address, resourceId]);
-      await erc4908Example.write.setAccess([resourceId, price, expirationDuration]);
+      await erc4908Example.write.setAccess([resourceId, price, expirationDuration, coOwner, splitFee]);
       const after = await erc4908Example.read.existAccess([wallet.account.address, resourceId]);
 
       /* Assert */
@@ -90,14 +92,14 @@ describe("ERC4908", function () {
       /* Arrange */
       
       const { erc4908Example, wallet } = await loadFixture(deployERC4908ExampleFixture);
-      const { resourceId, price, expirationDuration } = paramsDefault;
+      const { resourceId, price, expirationDuration, coOwner, splitFee } = paramsDefault;
       
       const expectedHash = keccak256(encodePacked(
         ['address', 'string'],
         [wallet.account.address, resourceId]
       ));
 
-      await erc4908Example.write.setAccess([resourceId, price, expirationDuration]);
+      await erc4908Example.write.setAccess([resourceId, price, expirationDuration, coOwner, splitFee]);
 
       /* Act */
 
@@ -125,227 +127,6 @@ describe("ERC4908", function () {
     });
   });
 
-  describe("Access minting", function () {
-    it("Should get access control values", async function () {
-
-      /* Arrange */
-
-      const { erc4908Example, wallets } = await loadFixture(deployERC4908ExampleFixture);
-      const { resourceId, price, expirationDuration } = paramsDefault;
-      const [Alice, Bob] = wallets;
-
-      let alice = await impersonate(erc4908Example, Alice);
-      let bob = await impersonate(erc4908Example, Bob);
-
-      await alice.write.setAccess([resourceId, price, expirationDuration]);
-
-      /* Act */
-
-      const accessControl = await bob.read.getAccessControl([Alice.account.address ,resourceId]);
-
-      /* Assert */
-
-      expect(accessControl[0]).to.equal(price);
-      expect(accessControl[1]).to.equal(expirationDuration);
-    });
-
-    it("Should test if NFT minting is available", async function () {
-
-      /* Arrange */
-
-      const { erc4908Example, wallets } = await loadFixture(deployERC4908ExampleFixture);
-      const { resourceId, price, expirationDuration } = paramsDefault;
-      const [Alice, Bob] = wallets;
-
-      let alice = await impersonate(erc4908Example, Alice);
-      let bob = await impersonate(erc4908Example, Bob);
-
-      await alice.write.setAccess([resourceId, price, expirationDuration]);
-
-      /* Act */
-
-      const mintUnavailableContent = alice.write.mint([
-        Bob.account.address, 
-        resourceId, 
-        Alice.account.address
-      ], { value: price })
-
-      const mintAvailableContent = bob.write.mint([
-        Alice.account.address,
-        resourceId,
-        Bob.account.address
-      ], { value: price })
-
-      /* Assert */
-      
-      await expect(mintUnavailableContent).to.be.rejectedWith(
-        'MintUnavailable("0x64b7b2d2900f927ae778f84917c8327d63cbb08f59126c14ead77f45b28ab7dd")'
-      );  
-      await expect(mintAvailableContent).to.be.fulfilled; 
-    });
-
-    it("Should check if the expected NFT price is met", async function () {
-      
-      /* Arrange */
-
-      const { erc4908Example, wallets } = await loadFixture(deployERC4908ExampleFixture);
-      const { resourceId, price, expirationDuration } = paramsDefault;
-      const [Alice, Bob] = wallets;
-
-      let alice = await impersonate(erc4908Example, Alice);
-      let bob = await impersonate(erc4908Example, Bob);
-
-      await alice.write.setAccess([resourceId, price, expirationDuration]);
-
-      /* Act */
-      
-      const mintInsufficientFunds = bob.write.mint([
-        Alice.account.address,
-        resourceId,
-        Bob.account.address
-      ], { value: price - 1n })
-
-      const mintSufficientFunds = bob.write.mint([
-        Alice.account.address,
-        resourceId,
-        Bob.account.address
-      ], { value: price })
-
-
-      /* Assert */
-
-      await expect(mintInsufficientFunds).to.be.rejectedWith(
-        'InsufficientFunds(2)'
-      );
-      await expect(mintSufficientFunds).to.be.fulfilled;
-    });
-
-    it("Should transfer the mint price to the author", async function () {
-
-      /* Arrange */
-
-      const { erc4908Example, wallets } = await loadFixture(deployERC4908ExampleFixture);
-      const { resourceId, price, expirationDuration } = paramsDefault;
-      const [Alice, Bob] = wallets;
-
-      let alice = await impersonate(erc4908Example, Alice);
-      let bob = await impersonate(erc4908Example, Bob);
-
-      /* Act */
-      
-      await alice.write.setAccess([resourceId, price, expirationDuration]);
-      const balanceAliceBefore = await getBalance(Alice.account.address);
-      const balanceBobBefore = await getBalance(Bob.account.address);
-      await bob.write.mint([Alice.account.address, resourceId, Bob.account.address], { value: price });
-      const balanceAliceAfter = await getBalance(Alice.account.address);
-      const balanceBobAfter = await getBalance(Bob.account.address);
-
-      /* Assert */
-      
-      expect(balanceAliceAfter).to.equal(balanceAliceBefore + price);
-      expect(Number(balanceBobAfter)).to.lessThanOrEqual(Number(balanceBobBefore - price));
-    });
-  });
-
-  describe("Resources access check", function () {
-    it("Should have access", async function () {
-      
-      /* Arrange */
-      
-      const { erc4908Example, wallets } = await loadFixture(deployERC4908ExampleFixture);
-      const { resourceId, price, expirationDuration } = paramsDefault;
-      const [Alice, Bob] = wallets;
-
-      let alice = await impersonate(erc4908Example, Alice);
-      let bob = await impersonate(erc4908Example, Bob);
-
-      await alice.write.setAccess([resourceId, price, expirationDuration]);
-
-      /* Act */
-      
-      const [hasAccessBeforeMint, messageBeforeMint, expirationTimeBeforeMint] = await erc4908Example.read.hasAccess([Alice.account.address, resourceId, Bob.account.address]);
-      
-      await bob.write.mint([Alice.account.address, resourceId, Bob.account.address], { value: price });
-      const mintTime = await getBlockTimestamp();
-
-      const [hasAccessAfterMint, messageAfterMint, expirationTimeAfterMint] = await erc4908Example.read.hasAccess([Alice.account.address, resourceId, Bob.account.address]);
-
-      /* Assert */
-      
-      expect(hasAccessBeforeMint).to.equal(false);
-      expect(messageBeforeMint).to.equal("user doesn't own the NFT");
-      expect(expirationTimeBeforeMint).to.equal(-1);
-
-      expect(hasAccessAfterMint).to.equal(true);
-      expect(messageAfterMint).to.equal("access granted");
-      expect(expirationTimeAfterMint).to.equal(mintTime + expirationDuration);
-    });
-
-    it("Should not have access", async function () {
-      /* Arrange */
-      const { erc4908Example, wallets } = await loadFixture(deployERC4908ExampleFixture);
-      const [Alice, Bob, Charlie] = wallets;
-      const { resourceId, price, expirationDuration } = paramsDefault;
-
-      let alice = await impersonate(erc4908Example, Alice);
-      let bob = await impersonate(erc4908Example, Bob);
-
-      await alice.write.setAccess([resourceId, price, expirationDuration]);
-
-      /* Act */
-      await bob.write.mint([Alice.account.address, resourceId, Bob.account.address], { value: price });
-      const [hasAccessCharlie, messageCharlie] = await erc4908Example.read.hasAccess([Alice.account.address, resourceId, Charlie.account.address]);
-
-      /* Assert */
-      expect(hasAccessCharlie).to.equal(false);
-      expect(messageCharlie).to.equal("user doesn't own the NFT");
-    });
-
-    it("Should detect expired access", async function () {
-      /* Arrange */
-      const { erc4908Example, wallets } = await loadFixture(deployERC4908ExampleFixture);
-      const [Alice, Bob] = wallets;
-      const { resourceId, price, expirationDuration } = paramsDefault;
-
-      let alice = await impersonate(erc4908Example, Alice);
-      let bob = await impersonate(erc4908Example, Bob);
-      await alice.write.setAccess([resourceId, price, expirationDuration]);
-
-      /* Act */
-      await bob.write.mint([Alice.account.address, resourceId, Bob.account.address], { value: price });
-      await increaseTime(1)
-      const [hasAccessBeforeExpiration, messageBeforeExpiration] = await erc4908Example.read.hasAccess([Alice.account.address, resourceId, Bob.account.address])
-      await increaseTime(3)
-      const [hasAccessAfterExpiration, messageAfterExpiration] = await erc4908Example.read.hasAccess([Alice.account.address, resourceId, Bob.account.address]);
-
-      /* Assert */
-      expect(hasAccessBeforeExpiration).to.equal(true);
-      expect(messageBeforeExpiration).to.equal("access granted");
-      expect(hasAccessAfterExpiration).to.equal(false);
-      expect(messageAfterExpiration).to.equal("access is expired");
-    });
-
-    it("Should allow access if at least one NFT is not expired", async function () {
-      /* Arrange */
-      const { erc4908Example, wallets } = await loadFixture(deployERC4908ExampleFixture);
-      const [Alice, Bob] = wallets;
-      const { resourceId, price, expirationDuration } = paramsDefault;
-
-      let alice = await impersonate(erc4908Example, Alice);
-      let bob = await impersonate(erc4908Example, Bob);
-      await alice.write.setAccess([resourceId, price, expirationDuration]);
-
-      /* Act */
-      await bob.write.mint([Alice.account.address, resourceId, Bob.account.address], { value: price });
-      await increaseTime(1)
-      await bob.write.mint([Alice.account.address, resourceId, Bob.account.address], { value: price });
-      await increaseTime(3)
-      const [hasAccess, _] = await erc4908Example.read.hasAccess([Alice.account.address, resourceId, Bob.account.address]);
-
-      expect(hasAccess).to.equal(true);
-    });
-  });
-
   describe("Interface support", function () {
     it("Should support ERC4908 interface", async function () {
       /* Arrange */
@@ -353,13 +134,12 @@ describe("ERC4908", function () {
       
       // Calculate interface ID from function selectors
       const functionSelectors = [
-        "setAccess(string,uint256,uint32)",
+        "setAccess(string,uint256,uint32,address,uint32)",
         "delAccess(string)",
         "hasAccess(address,string,address)",
         "existAccess(bytes32)",
         "existAccess(address,string)",
-        "getAccessControl(address,string)",
-        "mint(address,string,address)"
+        "getAccessControl(address,string)"
       ].map(sig => keccak256(encodePacked(['string'], [sig])).slice(0, 10));
 
       // XOR all function selectors to get interface ID
@@ -405,26 +185,6 @@ describe("ERC4908", function () {
   });
 
   describe("Edge cases", function () {
-    it("Should handle zero price minting", async function () {
-      /* Arrange */
-      const { erc4908Example, wallets } = await loadFixture(deployERC4908ExampleFixture);
-      const [Alice, Bob] = wallets;
-      const resourceId = "test-resource";
-      const price = 0n;
-      const expirationDuration = 3600;
-
-      let alice = await impersonate(erc4908Example, Alice);
-      let bob = await impersonate(erc4908Example, Bob);
-
-      /* Act */
-      await alice.write.setAccess([resourceId, price, expirationDuration]);
-      await bob.write.mint([Alice.account.address, resourceId, Bob.account.address], { value: price });
-
-      /* Assert */
-      const [hasAccess] = await erc4908Example.read.hasAccess([Alice.account.address, resourceId, Bob.account.address]);
-      expect(hasAccess).to.equal(true);
-    });
-
     it("Should not allow empty resourceId", async function () {
       /* Arrange */
       const { erc4908Example, wallet } = await loadFixture(deployERC4908ExampleFixture);
@@ -433,31 +193,11 @@ describe("ERC4908", function () {
       const expirationDuration = 3600;
 
       /* Act */
-      await erc4908Example.write.setAccess([resourceId, price, expirationDuration]);
+      await erc4908Example.write.setAccess([resourceId, price, expirationDuration, wallet.account.address, 0]);
 
       /* Assert */
       const exists = await erc4908Example.read.existAccess([wallet.account.address, resourceId]);
       expect(exists).to.equal(false);
-    });
-
-    it("Should handle large expiration duration", async function () {
-      /* Arrange */
-      const { erc4908Example, wallets } = await loadFixture(deployERC4908ExampleFixture);
-      const [Alice, Bob] = wallets;
-      const resourceId = "test-resource";
-      const price = 1n;
-      const expirationDuration = 0x7FFFFFFF; // Large but safe uint32 value
-
-      let alice = await impersonate(erc4908Example, Alice);
-      let bob = await impersonate(erc4908Example, Bob);
-
-      /* Act */
-      await alice.write.setAccess([resourceId, price, expirationDuration]);
-      await bob.write.mint([Alice.account.address, resourceId, Bob.account.address], { value: price });
-
-      /* Assert */
-      const [hasAccess] = await erc4908Example.read.hasAccess([Alice.account.address, resourceId, Bob.account.address]);
-      expect(hasAccess).to.equal(true);
     });
   });
 });

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -1,4 +1,5 @@
 import hre from "hardhat";
+import { zeroAddress } from "viem";
 
 /*
  * { impersonateAccount } from "@nomicfoundation/hardhat-toolbox-viem/network-helpers";
@@ -16,6 +17,8 @@ const paramsDefault = {
   resourceId: "7f0e683bd119688847070f0a4476d078b95399a2843ca1c549cdcdbafee0792f",
   price: BigInt(2),
   expirationDuration: 3,
+  coOwner: zeroAddress,
+  splitFee: 0,
 };
 
 async function increaseTime(seconds: number) {


### PR DESCRIPTION
This pull request introduces significant changes to the `ERC4908` contract and its associated interface, focusing on adding co-ownership functionality and removing NFT minting features. Additionally, the test suite has been updated to reflect these changes by removing minting-related tests and adding support for the new co-ownership parameters.

### Changes to the `ERC4908` contract:

* **Co-ownership support**:
  - Added `coOwner` and `splitFee` fields to the `Settings` struct to enable specifying a co-owner and their revenue share.
  - Updated the `_setAccess` and `setAccess` methods to include `coOwner` and `splitFee` parameters.
  - Updated the `getAccessControl` method to return `coOwner` and `splitFee`.

* **Removed NFT minting functionality**:
  - Deleted the `mint` method and related logic, removing the ability to mint NFTs directly through the contract.

### Changes to the `IERC4908` interface:

* **Co-ownership support**:
  - Updated the `setAccess` and `getAccessControl` methods to include `coOwner` and `splitFee` parameters and return values. [[1]](diffhunk://#diff-d95c60f2d2edbd567b3f90dd39c6d2b36ef5f586404ead79a035d18fc2daa54fR10-R17) [[2]](diffhunk://#diff-d95c60f2d2edbd567b3f90dd39c6d2b36ef5f586404ead79a035d18fc2daa54fR67-R72)

* **Removed NFT minting functionality**:
  - Removed the `mint` method and its documentation from the interface.

### Updates to the test suite:

* **Test adjustments for co-ownership**:
  - Updated `paramsDefault` in `test/utils.ts` to include `coOwner` and `splitFee` default values.
  - Modified test cases in `test/ERC4908Example.ts` to validate the new `coOwner` and `splitFee` fields in the `setAccess` and `getAccessControl` methods. [[1]](diffhunk://#diff-deba763870564fc6c38e576f39aaf7757749f798ac89c3f4a0309329495e72f3L26-R26) [[2]](diffhunk://#diff-deba763870564fc6c38e576f39aaf7757749f798ac89c3f4a0309329495e72f3L35-R52) [[3]](diffhunk://#diff-deba763870564fc6c38e576f39aaf7757749f798ac89c3f4a0309329495e72f3L60-R62) [[4]](diffhunk://#diff-deba763870564fc6c38e576f39aaf7757749f798ac89c3f4a0309329495e72f3L74-R81) [[5]](diffhunk://#diff-deba763870564fc6c38e576f39aaf7757749f798ac89c3f4a0309329495e72f3L93-R102)

* **Removed minting-related tests**:
  - Deleted all tests related to NFT minting, including tests for minting availability, price validation, revenue transfer, and access expiration. [[1]](diffhunk://#diff-deba763870564fc6c38e576f39aaf7757749f798ac89c3f4a0309329495e72f3L128-R142) [[2]](diffhunk://#diff-deba763870564fc6c38e576f39aaf7757749f798ac89c3f4a0309329495e72f3L408-L427) [[3]](diffhunk://#diff-deba763870564fc6c38e576f39aaf7757749f798ac89c3f4a0309329495e72f3L436-L461)

These changes add flexibility to the `ERC4908` contract by introducing co-ownership while simplifying the contract by removing minting functionality. The updates to the tests ensure that the new functionality is thoroughly validated.